### PR TITLE
Make things work

### DIFF
--- a/src/bramble/client/StateManager.js
+++ b/src/bramble/client/StateManager.js
@@ -51,6 +51,19 @@ define(function() {
         return str|0;
     }
 
+    function getObject(storage, property) {
+        var objStr = getString(storage, property);
+        var obj = null;
+
+        try {
+            obj = JSON.parse(objStr);
+        } catch(e) {
+            console.error("Failed to parse object from localStorage item " + prefix(property) + " with: ", e);
+        }
+
+        return obj;
+    }
+
     function StateManager(disableStorage) {
         var storage;
         if(disableStorage) {
@@ -103,8 +116,8 @@ define(function() {
                 set: function(v) { storage.setItem(prefix("wordWrap"), v); }
             },
             autoCloseTags: {
-                get: function()  { return getBool(storage, "closeTags"); },
-                set: function(v) { storage.setItem(prefix("closeTags"), v); }
+                get: function()  { return getObject(storage, "closeTags"); },
+                set: function(v) { storage.setItem(prefix("closeTags"), JSON.stringify(v)); }
             },
             allowJavaScript: {
                 get: function()  { return getBool(storage, "allowJavaScript"); },

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -919,13 +919,9 @@ define([
     BrambleProxy.prototype.disableWordWrap = function(callback) {
         this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_DISABLE_WORD_WRAP"}, callback);
     };
-	
-    BrambleProxy.prototype.enableAutoCloseTags = function(callback) {
-        this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_ENABLE_AUTO_CLOSE_TAGS"}, callback);
-    };
 
-    BrambleProxy.prototype.disableAutoCloseTags = function(callback) {
-        this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_DISABLE_AUTO_CLOSE_TAGS"}, callback);
+    BrambleProxy.prototype.configureAutoCloseTags = function(options, callback) {
+        this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_CONFIGURE_AUTO_CLOSE_TAGS", args: [ options ]}, callback);
     };
 
     BrambleProxy.prototype.showTutorial = function(callback) {
@@ -961,7 +957,7 @@ define([
     BrambleProxy.prototype.export = function(callback) {
         this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_EXPORT"}, callback);
     };
-	
+
     BrambleProxy.prototype.addCodeSnippet = function(options, callback) {
         this._executeRemoteCommand({
             commandCategory: "bramble",

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -110,7 +110,6 @@ define(function (require, exports, module) {
     exports.TOGGLE_LINE_NUMBERS         = "view.toggleLineNumbers";     // EditorOptionHandlers.js      _getToggler()
     exports.TOGGLE_ACTIVE_LINE          = "view.toggleActiveLine";      // EditorOptionHandlers.js      _getToggler()
     exports.TOGGLE_WORD_WRAP            = "view.toggleWordWrap";        // EditorOptionHandlers.js      _getToggler()
-    exports.TOGGLE_AUTO_CLOSE_TAGS      = "cmd.toggleAutoCloseTags";    // EditorOptionHandlers.js      _getToggler()
     exports.TOGGLE_ALLOW_JAVASCRIPT     = "cmd.toggleAllowJavaScript";  // EditorOptionsHandlers.js     _getToggler()
 
     exports.CMD_OPEN                        = "cmd.open";

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -97,7 +97,6 @@ define(function (require, exports, module) {
         USE_TAB_CHAR        = "useTabChar",
         WORD_WRAP           = "wordWrap",
         INDENT_LINE_COMMENT  = "indentLineComment",
-		AUTO_CLOSE_TAGS = "closeTags",
         ALLOW_JAVASCRIPT    = "allowJavaScript";
     
 
@@ -130,7 +129,6 @@ define(function (require, exports, module) {
     cmOptions[USE_TAB_CHAR]       = "indentWithTabs";
     cmOptions[WORD_WRAP]          = "lineWrapping";
     cmOptions[ALLOW_JAVASCRIPT]   = "allowJavaScript";
-	cmOptions[AUTO_CLOSE_TAGS]   = "autoCloseTags";
 
     PreferencesManager.definePreference(CLOSE_BRACKETS,     "boolean", true, {
         description: Strings.DESCRIPTION_CLOSE_BRACKETS

--- a/src/editor/EditorOptionHandlers.js
+++ b/src/editor/EditorOptionHandlers.js
@@ -36,7 +36,6 @@ define(function (require, exports, module) {
     var SHOW_LINE_NUMBERS = "showLineNumbers",
         STYLE_ACTIVE_LINE = "styleActiveLine",
         WORD_WRAP         = "wordWrap",
-        AUTO_CLOSE_TAGS   = "closeTags",
         ALLOW_JAVASCRIPT  = "allowJavaScript",
         CLOSE_BRACKETS    = "closeBrackets";
 
@@ -49,7 +48,6 @@ define(function (require, exports, module) {
     _optionMapping[SHOW_LINE_NUMBERS] = Commands.TOGGLE_LINE_NUMBERS;
     _optionMapping[STYLE_ACTIVE_LINE] = Commands.TOGGLE_ACTIVE_LINE;
     _optionMapping[WORD_WRAP] = Commands.TOGGLE_WORD_WRAP;
-    _optionMapping[AUTO_CLOSE_TAGS] = Commands.TOGGLE_AUTO_CLOSE_TAGS;
     _optionMapping[ALLOW_JAVASCRIPT] = Commands.TOGGLE_ALLOW_JAVASCRIPT;
     _optionMapping[CLOSE_BRACKETS] = Commands.TOGGLE_CLOSE_BRACKETS;
 
@@ -104,7 +102,6 @@ define(function (require, exports, module) {
 
     // XXXBramble
     CommandManager.registerInternal(Commands.TOGGLE_ALLOW_JAVASCRIPT, _getToggler(ALLOW_JAVASCRIPT));
-    CommandManager.registerInternal(Commands.TOGGLE_AUTO_CLOSE_TAGS, _getToggler(AUTO_CLOSE_TAGS));
 
     AppInit.htmlReady(_init);
 });

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -130,11 +130,8 @@ define(function (require, exports, module) {
         case "BRAMBLE_DISABLE_WORD_WRAP":
             PreferencesManager.set("wordWrap", false);
             break;
-        case "BRAMBLE_ENABLE_AUTO_CLOSE_TAGS":
-            PreferencesManager.set("closeTags", true);
-            break;
-        case "BRAMBLE_DISABLE_AUTO_CLOSE_TAGS":
-            PreferencesManager.set("closeTags", false);
+        case "BRAMBLE_CONFIGURE_AUTO_CLOSE_TAGS":
+            PreferencesManager.set("closeTags", args[0]);
             break;
         case "BRAMBLE_SHOW_TUTORIAL":
             Tutorial.setOverride(true);

--- a/src/extensions/default/bramble/lib/UI.js
+++ b/src/extensions/default/bramble/lib/UI.js
@@ -89,9 +89,9 @@ define(function (require, exports, module) {
         if(typeof wordWrap === "boolean") {
             PreferencesManager.set("wordWrap", wordWrap);
         }
-		
+
         var autoCloseTags = BrambleStartupState.ui("autoCloseTags");
-        if(typeof autoCloseTags === "boolean") {
+        if(typeof autoCloseTags === "object") {
             PreferencesManager.set("closeTags", autoCloseTags);
         }
 
@@ -116,11 +116,11 @@ define(function (require, exports, module) {
 
         var secondPaneWidth = BrambleStartupState.ui("secondPaneWidth");
         var firstPaneWidth = BrambleStartupState.ui("firstPaneWidth");
-                         
+
         firstPaneWidth = firstPaneWidth * 100 / (
                          ((firstPaneWidth)? firstPaneWidth : 0) +
                          ((secondPaneWidth)? secondPaneWidth : 0)); // calculate width in %
-        
+
         if(firstPaneWidth) {
             $("#first-pane").width((firstPaneWidth + "%"));
         }

--- a/src/extensions/default/bramble/main.js
+++ b/src/extensions/default/bramble/main.js
@@ -101,7 +101,6 @@ define(function (require, exports, module) {
         PreferencesManager.set("spaceUnits", 2);
         PreferencesManager.set("tabSize", 2);
         // Allows the closeTags to indent consistently
-        PreferencesManager.set("closeTags", true);
         // Don't warn about opening file in split view (we steal second view for iframe)
         PreferencesManager.setViewState("splitview.multipane-info", true);
 
@@ -156,7 +155,7 @@ define(function (require, exports, module) {
                     // Setup the iframe browser and Blob URL live dev servers and
                     // load the initial document into the preview.
                     startLiveDev();
-		
+
                     BrambleCodeSnippets.init();
 
                     UI.initUI(finishStartup);


### PR DESCRIPTION
Hey @cgsingh! Feel free to merge this into your branch or make these changes yourself.

Here's an explanation of the changes I have made:
- Apparently, the `closeTags` preference that already exists in Brackets does not use `boolean` values (which is what your previous PR and the PR I asked you to look at uses). It instead uses objects to configure the auto-close tags ability. You can see that [out here](https://github.com/mozilla/brackets/blob/master/src/editor/Editor.js#L136). So, I changed the api to accept an object as an argument instead and we store objects in `localStorage` as well. Instead of there being `enable/disable` on the API, we now just have `configure` so that you set whether you want it to be enabled or disabled using the `options` parameter you pass in.
- I removed some of the api changes that were made to `Editor` and `Commands` as we don't really need them

I think what's left to be done is to update the README so that it documents the new `configureAutoCloseTags` API instead along with the options it takes (the code I link to above shows you what options can be passed in). Then, on the Thimble side, you would pass in those options instead of calling `disable/enableAutoCloseTags`.

Let me know if you need any more info on the changes you need to make.